### PR TITLE
Extend Vimux to add option 'VimuxUseLast'

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -1,5 +1,8 @@
 # vimux
-
+## begin fork notes
+### Feature: VimuxUseLast
+`let g:VimuxUseLast = 1` => when choosing vimux runner pane, use last active tmux pane
+## end fork notes
 Easily interact with tmux from vim.
 
 ![vimux](https://www.braintreepayments.com/assets/images/blog/vimux3.png)

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -199,5 +199,5 @@ function! _VimuxTmuxProperty(property)
 endfunction
 
 function! _VimuxHasRunner(index)
-  return match(_VimuxTmux("list-"._VimuxRunnerType()."s -a"), a:index.":")
+  return match(_VimuxTmux("list-"._VimuxRunnerType()."s -a"), _VimuxTmuxSession().":".a:index.":")
 endfunction


### PR DESCRIPTION
Description:

Add option to use last-active tmux pane as runner pane.

When g:VimuxUseLast == 1, use last pane as runner pane. This pane can be in any window.
Notable effect: Vimux will only create a new pane when there is no last pane (i.e. last pane is the current pane)
Behavior could be changed to only use last pane if it resides in same window as vim, if this is preferred (Update: said change is in the most recent commit)
This option overrides g:VimUseNearest
206ecb fixes a (pre-existing) bug whereby Vimux would no longer create a new runner after closing the runner if a pane with same [window].[pane] signature exists in a different tmux session. If maintainer prefers only the bugfix or only the feature, they exist in different branches in my fork and this pull request can be easily amended.
Motivation:

Vimux offered no user-friendly way to make an arbitrary pane the runner. With this patch, a user can just select the pane they wish to be the runner, then selectp -t [vim's pane]. If the desired runner pane is a tmux keystroke away, there's no need to enter tmux command mode at all.

Disclaimer:

This is my first pull request, sorry if this violates your guidelines, is incomplete, and/or is poorly formatted